### PR TITLE
v0.4.0

### DIFF
--- a/peakplotter/__init__.py
+++ b/peakplotter/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-__version__ = '0.3.1'
+__version__ = '0.4.0.dev0'

--- a/peakplotter/__init__.py
+++ b/peakplotter/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-__version__ = '0.4.0.dev0'
+__version__ = '0.4.0'

--- a/peakplotter/_interactive_manh.py
+++ b/peakplotter/_interactive_manh.py
@@ -172,7 +172,9 @@ def get_csq_novel_variants(e, chrcol, pscol, a1col, a2col, server, logger):
     novelsnps=copied_e.loc[(copied_e['ensembl_rs']=="novel") & (copied_e['ld']>0.1) & (copied_e['ensembl_consequence']!='double allele'),]
     if novelsnps.empty:
         return copied_e
+    pd.options.mode.chained_assignment = None # Temporarily suppress the SettingWithCopyWarning message
     novelsnps['query']=novelsnps[chrcol].astype(str)+" "+novelsnps[pscol].astype(int).astype(str)+" . "+novelsnps[a1col].astype(str)+" "+novelsnps[a2col].astype(str)+" . . ."
+    pd.options.mode.chained_assignment = 'warn' # Reactivate the SettingWithCopyWarning message
     request='{ "variants" : ["'+'", "'.join(novelsnps['query'])+'" ] }'
     ext = "/vep/homo_sapiens/region"
     headers={ "Content-Type" : "application/json", "Accept" : "application/json"}

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -304,7 +304,7 @@ def make_peakplot(infile, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, l
     timestamp = datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')
     timestamp_text = f'Plot generated: {timestamp}'
     geneview.add_layout(Title(text=timestamp_text, align="right"), "below")
-    geneview.add_layout(Title(text=f'Version: {__version__}', align="right"), "below")
+    geneview.add_layout(Title(text=f'Version: v{__version__}', align="right"), "below")
 
     # Add centromere region info on geneview plot
     cen_start, cen_end = _interactive_manh.get_centromere_region(chrom, build)

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -56,9 +56,9 @@ class GenomeView(Figure):
             line_alpha = 'col_assoc')
         
         
-        chrom = set(e['chrom']).pop()
-        start = int(e['ps'].min())
-        end = int(e['ps'].max())
+        chrom = set(data['chrom']).pop()
+        start = int(data['ps'].min())
+        end = int(data['ps'].max())
         self.title = f'chr{chrom}:{start}-{end}'
 
         
@@ -268,8 +268,16 @@ def make_peakplot(infile, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, l
     start = e['ps'].min()
     end = e['ps'].max()
     extend = (end - start) * 0.025
-    genome.x_range.start = e['ps'].min() - extend
-    genome.x_range.end = e['ps'].max() + extend
+    genome.x_range.start = start - extend
+    genome.x_range.end = end + extend
+
+    start = e['logp'].min()
+    end = e['logp'].max()
+    extend = (end - start) * 0.025
+    genome.x_range.start = start
+    genome.x_range.end = end + extend
+
+    genome.add_layout(Title(text="logp", align="center"), "left")
     
     ## Make GeneView plot
     geneview = GeneView()

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -185,7 +185,9 @@ def make_view_data(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, lo
     d['col'] = pd.cut(d['ld'], 9, labels = Spectral10[1:])
 
     d['logp'] = -np.log10(d['p-value'])
-
+    # logp of variants with p-value of 1.0 is calculated as -0.0, which causes
+    # problem downstream (like during centromere overlap check in make_peakplot function)
+    d.loc[d['logp']==-0.0, 'logp'] = 0.0
 
     grouped_ff = _make_grouped_ff(chrom, start, end, build, logger)
 

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -1,17 +1,303 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*- 
 
 import sys
 
 import numpy as np
 import pandas as pd
 from bokeh.io import output_file
-from bokeh.models import HoverTool, TapTool, OpenURL, LabelSet, Span, Label, ColumnDataSource
+from bokeh.core.properties import Int
+from bokeh.models import HoverTool, TapTool, OpenURL, LabelSet, ColumnDataSource, TapTool, OpenURL, Title, CustomJS, RangeSlider, CustomJSFilter, CDSView
+from bokeh.models.formatters import NumeralTickFormatter
+
 from bokeh.layouts import gridplot
-from bokeh.plotting import figure, save
+from bokeh.plotting import Figure, figure, save
 from bokeh.palettes import Spectral10
 
 from . import _interactive_manh
+
+
+class GenomeView(Figure):
+    __subtype__ = "GenomeView"
+    __view_model__ = "Plot"
+    
+    hover = HoverTool(tooltips = [
+            ("name", "@rs"),
+            ("RS-id", "@ensembl_rs"),
+            ("ld", "@ld"),
+            ("M.A.F", "@maf"),
+            ("overlaps gene", "@gene"),
+            ("consequence", "@ensembl_consequence"),
+            ("known associations", "@ensembl_assoc")
+    ])
+    
+    def __init__(self, *args, width = 1500, **kw):
+        if 'tools' not in kw:
+            kw['tools'] = [self.hover, 'box_zoom,wheel_zoom,undo,redo,reset,tap']
+        
+        super().__init__(*args, width = width, **kw)
+        
+        self.xaxis.formatter = NumeralTickFormatter()
+        self.toolbar_location="above"
+        
+    def update_view(self, data, build = 38):
+        source = ColumnDataSource(data)
+        server = "http://ensembl.org" if build==38 else "http://grch37.ensembl.org"
+        url = f"{server}/Homo_sapiens/Variation/Explore?v=@ensembl_rs"
+        taptool = self.select(type=TapTool)
+        taptool.callback = OpenURL(url=url)
+        self.circle(
+            'ps', 
+            'logp', 
+            line_width = 2, 
+            source = source, 
+            size = 9, 
+            fill_color = 'col', 
+            line_color = "black", 
+            line_alpha = 'col_assoc')
+        
+        
+        chrom = set(e['chrom']).pop()
+        start = int(e['ps'].min())
+        end = int(e['ps'].max())
+        self.title = f'chr{chrom}:{start}-{end}'
+
+        
+class GeneView(Figure):
+    __subtype__ = 'GeneView'
+    __view_model__ = "Plot"
+    
+    line_width = Int(4, help="The thickness of the gene plotted.")
+    
+    def __init__(self, *args, height = 300, width = 1500, **kw):
+        if 'tools' not in kw:
+            kw['tools'] = ['tap']
+            
+        super().__init__(*args, height = height, width = width, **kw)
+        
+        self.xaxis.formatter = NumeralTickFormatter()
+        self.yaxis.visible = False
+
+    def update_view(self, data):
+        if self.renderers:
+            for seg in self.renderers:
+                seg.visible = False
+            labels = self.select(LabelSet)
+            for lab in labels:
+                lab.visible = False
+                
+            
+        genes = data.copy()
+        
+        gene_count = data.shape[0]
+        rng = np.random.default_rng()
+        ys = rng.choice(gene_count, size=gene_count, replace=False)
+
+        genes['y'] = ys
+
+        genes['color'] = "cornflowerblue"
+        genes['protein_coding'] = 'not protein coding'
+        genes.loc[genes['biotype']=="protein_coding", 'color']="goldenrod"
+        genes.loc[genes['biotype']=="protein_coding", 'protein_coding']="protein coding"
+
+        genes['sens'] = "<"
+        genes.loc[genes['strand']>0, 'sens'] = ">"
+        
+        no_names = genes['external_name'] == ''
+        genes.loc[no_names, 'external_name'] = genes.loc[no_names, 'gene_id']
+
+        genes['name'] = genes['sens'] + genes['external_name']
+        
+        # source = ColumnDataSource(genes)
+        
+        for _type in ('not protein coding', 'protein coding'):
+            subset_source = ColumnDataSource(genes.loc[genes['protein_coding']==_type])
+            segments = self.segment(
+                source = subset_source,
+                x0='start',
+                x1='end',
+                y0='y',
+                y1='y',
+                line_width=self.line_width,
+                color='color',
+                legend_label = _type
+            )
+            
+            labels = LabelSet(x='start', y='y', text='name', source = subset_source)
+            self.add_layout(labels)
+            
+            segments.js_on_change('visible', CustomJS(args={'ls': labels}, code="ls.visible = cb_obj.visible;"))
+            
+
+        # labels = LabelSet(x='start', y='y', text='name', source=source)
+        # self.add_layout(labels)
+        self.legend.location = "top_left"
+        self.legend.click_policy="hide"
+
+
+def _make_grouped_ff(chrom, start, end, build, logger):
+    server = _interactive_manh.get_build_server(build)
+    ff = _interactive_manh.get_rsid_in_region(chrom, start, end, server, logger)
+    logger.debug(ff.head())
+    columns = ['ensembl_rs', 'ps', 'ensembl_consequence', 'ensembl_assoc']
+    ff.columns = columns
+
+    dedup_ff = ff[~ff['ps'].duplicated(keep = False)]
+    dup_ff = ff[ff['ps'].duplicated(keep = False)]
+    grouped_dup_ff = dup_ff.groupby('ps').apply(lambda x: pd.Series({
+                        'ensembl_consequence': ";".join(x['ensembl_consequence'].unique()),
+                        'ensembl_rs': ";".join(x['ensembl_rs'].unique()),
+                        'ensembl_assoc': ";".join(set(x['ensembl_assoc']))}))\
+                    .reset_index()
+
+    grouped_ff = pd.concat([
+                    dedup_ff[columns],
+                    grouped_dup_ff[columns]
+                ]).sort_values('ps').reset_index(drop = True)
+    
+    grouped_ff['ps'] = grouped_ff['ps'].astype(int)
+    
+    return grouped_ff
+
+
+def make_view_data(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, logger):
+    d = pd.read_csv(file, sep=",",index_col=False)
+    d.replace(r'\s+', np.nan, regex=True, inplace = True)
+    d.rename(inplace = True, 
+             columns = {
+                 pvalcol: 'p-value',
+                 chrcol: 'chrom',
+                 pscol: 'ps',
+                 a1col: 'a1',
+                 a2col: 'a2',
+                 mafcol: 'maf'
+             }
+    )
+
+    chrom = set(d['chrom']) # This is for later to check whether the region window overlaps a centromere.
+    assert len(chrom)==1, "The chromosome spans across multiple chromosomes, which is impossible."
+    chrom = int(chrom.pop())
+    start = int(d['ps'].min())
+    end = int(d['ps'].max())
+    server = _interactive_manh.get_build_server(build)
+
+    # LD colour
+    d['col'] = pd.cut(d['ld'], 9, labels = Spectral10[1:])
+
+    d['logp'] = -np.log10(d['p-value'])
+
+
+    grouped_ff = _make_grouped_ff(chrom, start, end, build, logger)
+
+
+    d = pd.merge(d, grouped_ff, on='ps', how='left')
+    d['ensembl_rs'].fillna('novel', inplace = True)
+    d['ensembl_consequence'].fillna('novel', inplace = True)
+
+    d['ensembl_assoc'].replace('', np.nan, inplace = True)
+    d['ensembl_assoc'].fillna("none", inplace=True)
+
+    # Create the alpha vector for associations in LD
+    d['col_assoc']=0
+    d.loc[(d['ensembl_assoc']!="none") & (d['ld']>0.1), 'col_assoc']=1
+    d['col_assoc'] = d['col_assoc'].astype(int)
+
+
+
+    # ENSEMBL consequences for variants in LD that do not have rs-ids
+    # logger.debug(f"e=_interactive_manh.get_csq_novel_variants(e, '{chrcol}', '{pscol}', '{a1col}', '{a2col}', '{server}', logger)")
+    e = _interactive_manh.get_csq_novel_variants(d, 'chrom', 'ps', 'a1', 'a2', server, logger)
+
+    genes = _interactive_manh.get_overlap_genes(chrom, start, end, server, logger)
+    f_genes = genes[genes['external_name']!='']
+    e['gene']=""
+    for index, row in f_genes.iterrows():
+        external_name = row['external_name']
+        if external_name=='':
+            # TODO: This case is things like pseudogenes, IncRNA, and rRNA genes.
+            # Check with Arthur whether these genes should just be removed completely
+            external_name = row['biotype']
+        overlap = (e['ps']>row['start']) & (e['ps']<row['end'])
+        e.loc[overlap, 'gene']=e.loc[overlap, 'gene']+";"+external_name
+    e['gene'] = e['gene'].str.replace(r'^\;', '')
+    
+    return e, genes
+
+
+def make_peakplot(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, logger):
+    ## Prepare data to create peakplot
+    e, genes = make_view_data(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, logger)
+    
+    ## Make GenomeView plot
+    genome = GenomeView()
+    source = ColumnDataSource(e)
+    # Make LD range slider
+    range_slider = RangeSlider(start = 0.0, end = 1.0, value = (0.0, 1.0), step = 0.01, title = 'LD')
+    range_slider.js_on_change('value', CustomJS(args=dict(source=source), code="source.change.emit()"))
+
+    js_filter = CustomJSFilter(args = dict(slider = range_slider, d = source), code="""
+        const start = slider.value[0]
+        const end = slider.value[1]
+        const indices = []
+
+        for (var i=0; i < source.get_length(); i++) {
+            var ld = d.data["ld"][i]
+            if (start <= ld && ld <= end) {
+                indices.push(i)
+            }
+        }
+        return indices
+    """)
+
+    view = CDSView(source = source, filters = [js_filter])
+
+    genome.circle(
+        'ps', 
+        'logp', 
+        source = source,
+        view = view,
+        line_width = 2, 
+        size = 9, 
+        fill_color = 'col', 
+        line_color = "black", 
+        line_alpha = 'col_assoc')
+    
+    # Slightly extend the edges for viewability
+    chrom = set(e['chrom']).pop()
+    start = e['ps'].min()
+    end = e['ps'].max()
+    extend = (end - start) * 0.025
+    genome.x_range.start = e['ps'].min() - extend
+    genome.x_range.end = e['ps'].max() + extend
+    
+    ## Make GeneView plot
+    geneview = GeneView()
+    geneview.update_view(genes)
+    geneview.add_layout(Title(text="base position", align="center"), "below")
+    geneview.x_range = genome.x_range
+    
+    # Add centromere region info on geneview plot
+    cen_start, cen_end = _interactive_manh.get_centromere_region(chrom, build)
+    cen_coordinate = set(range(cen_start, cen_end))
+    region = set(range(start, end))
+    cen_overlap = region.intersection(cen_coordinate)
+
+    if (len(cen_overlap)>0): # Add indication of the centromeric region in the plot
+        perc_overlap=int((len(cen_overlap)/len(region))*100)
+        logger.info("\t\t\t    {0}% of the genomic region overlaps a centromere".format(perc_overlap))
+
+        xs = min(cen_overlap)
+        xe = max(cen_overlap)+1
+        cen_median = max(cen_overlap)-int((max(cen_overlap)-min(cen_overlap))/2)
+        geneview.segment(x0=xs, x1=xe, y0=0.5, y1=0.5, line_width=100, color="grey")
+        cen = dict(x=[cen_median], y=[0.9], text=["Centromeric_region"])
+        labels = LabelSet(x="x", y="y", text="text",  source=ColumnDataSource(cen))
+        geneview.add_layout(labels)
+    
+    
+    ## Make peakplot
+    peakplot = gridplot([[range_slider], [genome], [geneview]])
+    return peakplot
+
 
 def interactive_manh(file, pvalcol, pscol, mafcol, chrcol, a1col, a2col, build: str, logger):
     outfile=file+".html"

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -196,6 +196,8 @@ def make_view_data(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, lo
 
     d['ensembl_assoc'].replace('', np.nan, inplace = True)
     d['ensembl_assoc'].fillna("none", inplace=True)
+    # Remove duplicate entries of ensembl_assoc 
+    d['ensembl_assoc'] = [';'.join(set(i.split(';'))) for i in d['ensembl_assoc']]
 
     # Create the alpha vector for associations in LD
     d['col_assoc']=0
@@ -324,6 +326,7 @@ def output_peakplot(infile, outfile, title, pvalcol, pscol, mafcol, chrcol, a1co
         logger = logger
     )
     save(peakplot)
+
 
 def interactive_manh(file, pvalcol, pscol, mafcol, chrcol, a1col, a2col, build: str, logger):
     outfile=file+".html"

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -7,8 +7,8 @@ import pandas as pd
 from bokeh.io import output_file
 from bokeh.core.properties import Int
 from bokeh.models import HoverTool, TapTool, OpenURL, LabelSet, ColumnDataSource, TapTool, OpenURL, Title, CustomJS, RangeSlider, CustomJSFilter, CDSView
+from bokeh.models.plots import Plot
 from bokeh.models.formatters import NumeralTickFormatter
-
 from bokeh.layouts import gridplot
 from bokeh.plotting import Figure, figure, save
 from bokeh.palettes import Spectral10

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import functools
+from datetime import datetime
 
 import numpy as np
 import pandas as pd
@@ -12,6 +13,7 @@ from bokeh.layouts import gridplot
 from bokeh.plotting import Figure, figure, save
 from bokeh.palettes import Spectral10
 
+from . import __version__
 from . import _interactive_manh
 
 
@@ -298,6 +300,11 @@ def make_peakplot(infile, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, l
     geneview.update_view(genes)
     geneview.add_layout(Title(text="base position", align="center"), "below")
     geneview.x_range = genome.x_range
+
+    timestamp = datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')
+    timestamp_text = f'Plot generated: {timestamp}'
+    geneview.add_layout(Title(text=timestamp_text, align="right"), "below")
+    geneview.add_layout(Title(text=f'Version: {__version__}', align="right"), "below")
 
     # Add centromere region info on geneview plot
     cen_start, cen_end = _interactive_manh.get_centromere_region(chrom, build)

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -223,13 +223,14 @@ def make_view_data(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, lo
     return e, genes
 
 
-def make_peakplot(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, logger):
+def make_peakplot(infile, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, logger):
     ## Prepare data to create peakplot
-    e, genes = make_view_data(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, logger)
+    e, genes = make_view_data(infile, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, logger)
     
     ## Make GenomeView plot
     genome = GenomeView()
     source = ColumnDataSource(e)
+
     # Make LD range slider
     range_slider = RangeSlider(start = 0.0, end = 1.0, value = (0.0, 1.0), step = 0.01, title = 'LD')
     range_slider.js_on_change('value', CustomJS(args=dict(source=source), code="source.change.emit()"))
@@ -299,11 +300,11 @@ def make_peakplot(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, log
     return peakplot
 
 
-def output_peakplot(input_file, output_file, title, pvalcol, pscol, mafcol, chrcol, a1col, a2col, build: str, logger):
-    output_file(filename = output_file, title = title)
+def output_peakplot(infile, outfile, title, pvalcol, pscol, mafcol, chrcol, a1col, a2col, build: str, logger):
+    output_file(filename = outfile, title = title)
 
     peakplot = make_peakplot(
-        file = input_file,
+        infile = infile,
         chrcol = chrcol,
         pscol = pscol,
         a1col = a1col,

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -7,7 +7,6 @@ import pandas as pd
 from bokeh.io import output_file
 from bokeh.core.properties import Int
 from bokeh.models import HoverTool, TapTool, OpenURL, LabelSet, ColumnDataSource, TapTool, OpenURL, Title, CustomJS, RangeSlider, CustomJSFilter, CDSView
-from bokeh.models.plots import Plot
 from bokeh.models.formatters import NumeralTickFormatter
 from bokeh.layouts import gridplot
 from bokeh.plotting import Figure, figure, save
@@ -18,7 +17,7 @@ from . import _interactive_manh
 
 class GenomeView(Figure):
     __subtype__ = "GenomeView"
-    __view_model__ = "Plot"
+    __view_model__ = "bokeh.models.plots.Plot"
     
     hover = HoverTool(tooltips = [
             ("name", "@rs"),
@@ -64,7 +63,7 @@ class GenomeView(Figure):
         
 class GeneView(Figure):
     __subtype__ = 'GeneView'
-    __view_model__ = "Plot"
+    __view_model__ = "bokeh.models.plots.Plot"
     
     line_width = Int(4, help="The thickness of the gene plotted.")
     

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -21,6 +21,7 @@ class GenomeView(Figure):
     __view_model__ = "Plot"
     
     hover = HoverTool(tooltips = [
+            ("==============", "=============="),
             ("name", "@rs"),
             ("RS-id", "@ensembl_rs"),
             ("ld", "@ld"),

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -185,10 +185,7 @@ def make_view_data(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, lo
     d['col'] = pd.cut(d['ld'], 9, labels = Spectral10[1:])
 
     d['logp'] = -np.log10(d['p-value'])
-    # logp of variants with p-value of 1.0 is calculated as -0.0, which causes
-    # problem downstream (like during centromere overlap check in make_peakplot function)
-    d.loc[d['logp']==-0.0, 'logp'] = 0.0
-
+    
     grouped_ff = _make_grouped_ff(chrom, start, end, build, logger)
 
 
@@ -269,17 +266,17 @@ def make_peakplot(infile, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, l
     
     # Slightly extend the edges for viewability
     chrom = set(e['chrom']).pop()
-    start = e['ps'].min()
-    end = e['ps'].max()
-    extend = (end - start) * 0.025
-    genome.x_range.start = start - extend
-    genome.x_range.end = end + extend
+    x_start = e['ps'].min()
+    x_end = e['ps'].max()
+    extend = (x_end - x_start) * 0.025
+    genome.x_range.start = x_start - extend
+    genome.x_range.end = x_end + extend
 
-    start = e['logp'].min()
-    end = e['logp'].max()
-    extend = (end - start) * 0.025
-    genome.x_range.start = start
-    genome.x_range.end = end + extend
+    y_start = e['logp'].min()
+    y_end = e['logp'].max()
+    extend = (y_end - y_start) * 0.025
+    genome.y_range.start = y_start
+    genome.y_range.end = y_end + extend
 
     genome.add_layout(Title(text="logp", align="center"), "left")
     
@@ -292,7 +289,7 @@ def make_peakplot(infile, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, l
     # Add centromere region info on geneview plot
     cen_start, cen_end = _interactive_manh.get_centromere_region(chrom, build)
     cen_coordinate = set(range(cen_start, cen_end))
-    region = set(range(start, end))
+    region = set(range(x_start, x_end))
     cen_overlap = region.intersection(cen_coordinate)
 
     if (len(cen_overlap)>0): # Add indication of the centromeric region in the plot

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -69,7 +69,7 @@ class GeneView(Figure):
     
     line_width = Int(4, help="The thickness of the gene plotted.")
     
-    def __init__(self, *args, height = 300, width = 1500, **kw):
+    def __init__(self, *args, height = 500, width = 1500, **kw):
         if 'tools' not in kw:
             kw['tools'] = ['tap']
             

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -301,6 +301,8 @@ def make_peakplot(infile, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, l
     geneview.add_layout(Title(text="base position", align="center"), "below")
     geneview.x_range = genome.x_range
 
+    geneview.add_layout(Title(text=f'chr{chrom}:{x_start}-{x_end}', align="right"), "below")
+
     timestamp = datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')
     timestamp_text = f'Plot generated: {timestamp}'
     geneview.add_layout(Title(text=timestamp_text, align="right"), "below")

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -17,7 +17,8 @@ from . import _interactive_manh
 
 class GenomeView(Figure):
     __subtype__ = "GenomeView"
-    __view_model__ = "bokeh.models.plots.Plot"
+    __view_module__ = ''
+    __view_model__ = "Plot"
     
     hover = HoverTool(tooltips = [
             ("name", "@rs"),
@@ -63,7 +64,8 @@ class GenomeView(Figure):
         
 class GeneView(Figure):
     __subtype__ = 'GeneView'
-    __view_model__ = "bokeh.models.plots.Plot"
+    __view_module__ = ''
+    __view_model__ = "Plot"
     
     line_width = Int(4, help="The thickness of the gene plotted.")
     

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -299,6 +299,22 @@ def make_peakplot(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, log
     return peakplot
 
 
+def output_peakplot(input_file, output_file, title, pvalcol, pscol, mafcol, chrcol, a1col, a2col, build: str, logger):
+    output_file(filename = output_file, title = title)
+
+    peakplot = make_peakplot(
+        file = input_file,
+        chrcol = chrcol,
+        pscol = pscol,
+        a1col = a1col,
+        a2col = a2col,
+        pvalcol = pvalcol,
+        mafcol = mafcol,
+        build = build,
+        logger = logger
+    )
+    save(peakplot)
+
 def interactive_manh(file, pvalcol, pscol, mafcol, chrcol, a1col, a2col, build: str, logger):
     outfile=file+".html"
 

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -17,7 +17,7 @@ from . import _interactive_manh
 
 class GenomeView(Figure):
     __subtype__ = "GenomeView"
-    __view_module__ = ''
+    __view_module__ = "bokeh" # https://github.com/bokeh/bokeh/issues/9412
     __view_model__ = "Plot"
     
     hover = HoverTool(tooltips = [
@@ -64,7 +64,7 @@ class GenomeView(Figure):
         
 class GeneView(Figure):
     __subtype__ = 'GeneView'
-    __view_module__ = ''
+    __view_module__ = "bokeh"
     __view_model__ = "Plot"
     
     line_width = Int(4, help="The thickness of the gene plotted.")

--- a/peakplotter/main.py
+++ b/peakplotter/main.py
@@ -178,7 +178,7 @@ def cli_region(assoc_file, bfiles, outdir, chr_col, pos_col, rs_col, pval_col, a
     }
 
     log_level = logging.DEBUG if debug else logging.INFO
-    logger = make_logger(outdir.joinpath(f'{outdir.name}.log'), level = log_level)
+    logger = make_logger(outdir.joinpath(f'{outdir.name}.{chrom}.{start}.{end}.log'), level = log_level)
     logger.info(f'PeakPlotter Version: {__version__}')
     arg_string = '\nArguments: \n'
     for k, v in configs.items():

--- a/peakplotter/plotpeaks.py
+++ b/peakplotter/plotpeaks.py
@@ -286,6 +286,9 @@ def process_peak(assocfile: str,
     logger.debug(f"Running make_peakplot")
     
     input_file = str(joined_peakdata_ld_file)
+    outfile = input_file+".html"
+    output_file(outfile)
+
     peakplot = make_peakplot(
         file = input_file,
         chrcol = chr_col,
@@ -297,9 +300,6 @@ def process_peak(assocfile: str,
         build = b,
         logger = logger
     )
-
-    outfile = input_file+".html"
-    output_file(outfile)
     save(peakplot)
 
     logger.info(f"Done with peak {chrom} {start} {end}.")

--- a/peakplotter/plotpeaks.py
+++ b/peakplotter/plotpeaks.py
@@ -8,12 +8,10 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from bokeh.io import output_file
-from bokeh.plotting import save
 
 from .tools import Plink, plink_exclude_across_bfiles
 from .peakit import peakit
-from .interactive_manh import make_peakplot
+from .interactive_manh import output_peakplot
 
 def read_assoc(filepath, chr_col, pos_col, pval_col, maf_col, rs_col, a1_col, a2_col, logger, chunksize = 10000) -> pd.DataFrame:
     """
@@ -286,21 +284,20 @@ def process_peak(assocfile: str,
     logger.debug(f"Running make_peakplot")
     
     input_file = str(joined_peakdata_ld_file)
-    outfile = input_file+".html"
-    output_file(outfile)
-
-    peakplot = make_peakplot(
-        file = input_file,
-        chrcol = chr_col,
+    output_file = input_file+".html"
+    title = f"chr{chrom}:{start}-{end}"
+    output_peakplot(
+        input_file = input_file,
+        output_file = output_file,
+        title = title,
+        pvalcol = pval_col,
         pscol = pos_col,
+        mafcol = maf_col,
+        chrcol = chr_col,
         a1col = a1_col,
         a2col = a2_col,
-        pvalcol = pval_col,
-        mafcol = maf_col,
         build = b,
-        logger = logger
-    )
-    save(peakplot)
+        logger = logger)
 
     logger.info(f"Done with peak {chrom} {start} {end}.")
     logger.info("Cleaning plink binary files")

--- a/peakplotter/plotpeaks.py
+++ b/peakplotter/plotpeaks.py
@@ -287,8 +287,8 @@ def process_peak(assocfile: str,
     output_file = input_file+".html"
     title = f"chr{chrom}:{start}-{end}"
     output_peakplot(
-        input_file = input_file,
-        output_file = output_file,
+        infile = input_file,
+        outfile = output_file,
         title = title,
         pvalcol = pval_col,
         pscol = pos_col,

--- a/peakplotter/plotpeaks.py
+++ b/peakplotter/plotpeaks.py
@@ -5,12 +5,15 @@ from typing import List
 import subprocess as sp
 from pathlib import Path
 
-import pandas as pd
+
 import numpy as np
+import pandas as pd
+from bokeh.io import output_file
+from bokeh.plotting import save
 
 from .tools import Plink, plink_exclude_across_bfiles
 from .peakit import peakit
-from .interactive_manh import interactive_manh
+from .interactive_manh import make_peakplot
 
 def read_assoc(filepath, chr_col, pos_col, pval_col, maf_col, rs_col, a1_col, a2_col, logger, chunksize = 10000) -> pd.DataFrame:
     """
@@ -280,8 +283,24 @@ def process_peak(assocfile: str,
     elif build == 37:
         b = 'b37'
     
-    logger.debug(f"interactive_manh({str(joined_peakdata_ld_file)}, {pval_col}, {pos_col}, {maf_col}, {chr_col}, {a1_col}, {a2_col}, build = {b})")
-    interactive_manh(str(joined_peakdata_ld_file), pval_col, pos_col, maf_col, chr_col, a1_col, a2_col, build = b, logger = logger)
+    logger.debug(f"Running make_peakplot")
+    
+    input_file = str(joined_peakdata_ld_file)
+    peakplot = make_peakplot(
+        file = input_file,
+        chrcol = chr_col,
+        pscol = pos_col,
+        a1col = a1_col,
+        a2col = a2_col,
+        pvalcol = pval_col,
+        mafcol = maf_col,
+        build = b,
+        logger = logger
+    )
+
+    outfile = input_file+".html"
+    output_file(outfile)
+    save(peakplot)
 
     logger.info(f"Done with peak {chrom} {start} {end}.")
     logger.info("Cleaning plink binary files")


### PR DESCRIPTION
**Changelog:**

- Big changes in the `interactive_manh.py` script to generate `.html` peakplot file.
  - There's now an LD slider at the top of the plot which can be used to hide variants outside the range of the slider.
  - You can now click on the gene view plot's legend to hide and show `protein coding` and `non-protein coding` genes.
  - You can now click on the genome view plot's legend to hide and show variants with previous association and variants with no previous association.
  - Genes with no `external_name` will now display their Ensembl gene ID instead