### PR TITLE
v0.4.3

### DIFF
--- a/peakplotter/__init__.py
+++ b/peakplotter/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-__version__ = '0.4.2'
+__version__ = '0.4.3.dev0'

--- a/peakplotter/__init__.py
+++ b/peakplotter/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-__version__ = '0.4.3.dev1'
+__version__ = '0.4.3'

--- a/peakplotter/__init__.py
+++ b/peakplotter/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-__version__ = '0.4.3.dev0'
+__version__ = '0.4.3.dev1'

--- a/peakplotter/interactive_manh.py
+++ b/peakplotter/interactive_manh.py
@@ -203,7 +203,7 @@ def make_view_data(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, lo
 
     # Create the alpha vector for associations in LD
     d['col_assoc']=0
-    d.loc[(d['ensembl_assoc']!="none") & (d['ld']>0.1), 'col_assoc']=1
+    d.loc[d['ensembl_assoc']!="none", 'col_assoc']=1
     d['col_assoc'] = d['col_assoc'].astype(int)
 
 
@@ -231,7 +231,7 @@ def make_view_data(file, chrcol, pscol, a1col, a2col, pvalcol, mafcol, build, lo
 def _create_peakplot(e, genes, build, logger):
     ## Make GenomeView plot
     genome = GenomeView()
-    range_slider = RangeSlider(start = 0.0, end = 1.0, value = (0.0, 1.0), step = 0.01, title = 'LD')
+    range_slider = RangeSlider(start = -0.01, end = 1.0, value = (-0.01, 1.0), step = 0.01, title = 'LD')
 
     p_CustomJSFilter = functools.partial(CustomJSFilter, code="""
         const start = slider.value[0]

--- a/peakplotter/plotpeaks.py
+++ b/peakplotter/plotpeaks.py
@@ -269,6 +269,7 @@ def process_peak(assocfile: str,
     peakdata.to_csv(peakdata_file, sep = '\t', header = True, index = False)
 
     joined_peakdata_ld = peakdata.merge(subset_ld_data, on = rs_col, how = 'left')
+    joined_peakdata_ld['ld'].fillna(-1)
     joined_peakdata_ld_file = outdir.joinpath(f'{chrom}.{start}.{end}.500kb')
     joined_peakdata_ld.to_csv(joined_peakdata_ld_file, sep = ',', header = True, index = False)
 

--- a/peakplotter/plotpeaks.py
+++ b/peakplotter/plotpeaks.py
@@ -269,7 +269,8 @@ def process_peak(assocfile: str,
     peakdata.to_csv(peakdata_file, sep = '\t', header = True, index = False)
 
     joined_peakdata_ld = peakdata.merge(subset_ld_data, on = rs_col, how = 'left')
-    joined_peakdata_ld['ld'].fillna(-1)
+    joined_peakdata_ld['ld'].fillna(-0.01)
+    joined_peakdata_ld['ld'] = joined_peakdata_ld['ld'].astype(float)
     joined_peakdata_ld_file = outdir.joinpath(f'{chrom}.{start}.{end}.500kb')
     joined_peakdata_ld.to_csv(joined_peakdata_ld_file, sep = ',', header = True, index = False)
 

--- a/peakplotter/plotpeaks.py
+++ b/peakplotter/plotpeaks.py
@@ -267,10 +267,11 @@ def process_peak(assocfile: str,
 
     peakdata_file = outdir.joinpath(f'{chrom}.{start}.{end}.peakdata.header')
     peakdata.to_csv(peakdata_file, sep = '\t', header = True, index = False)
-
+    logger.debug('Merging LD info to main dataframe')
     joined_peakdata_ld = peakdata.merge(subset_ld_data, on = rs_col, how = 'left')
-    joined_peakdata_ld['ld'].fillna(-0.01)
+    joined_peakdata_ld['ld'].fillna(-0.01, inplace = True)
     joined_peakdata_ld['ld'] = joined_peakdata_ld['ld'].astype(float)
+    logger.debug(joined_peakdata_ld['ld'])
     joined_peakdata_ld_file = outdir.joinpath(f'{chrom}.{start}.{end}.500kb')
     joined_peakdata_ld.to_csv(joined_peakdata_ld_file, sep = ',', header = True, index = False)
 

--- a/peakplotter/plotpeaks.py
+++ b/peakplotter/plotpeaks.py
@@ -268,7 +268,7 @@ def process_peak(assocfile: str,
     peakdata_file = outdir.joinpath(f'{chrom}.{start}.{end}.peakdata.header')
     peakdata.to_csv(peakdata_file, sep = '\t', header = True, index = False)
 
-    joined_peakdata_ld = peakdata.merge(subset_ld_data, on = rs_col)
+    joined_peakdata_ld = peakdata.merge(subset_ld_data, on = rs_col, how = 'left')
     joined_peakdata_ld_file = outdir.joinpath(f'{chrom}.{start}.{end}.500kb')
     joined_peakdata_ld.to_csv(joined_peakdata_ld_file, sep = ',', header = True, index = False)
 

--- a/test/test_peakit.py
+++ b/test/test_peakit.py
@@ -119,3 +119,36 @@ def test_PeakCollection_merge5_realworld_issue():
             ]
     peaks.merge()
     assert peaks == expected
+
+def test_PeakCollection_merge6_realworld_issue():
+    """
+    This checks something very different from the above!
+    So don't delete this thinking it's the same!
+    """
+    peaks = PeakCollection(1_000_000)
+    peaks[:] = [
+            Peak(11, 30000, 60000),
+            Peak(11, 5000000, 6000000),
+            ]
+    expected = PeakCollection(1_000_000)
+    expected[:] = [
+            Peak(11, 30000, 60000),
+            Peak(11, 5000000, 6000000),
+            ]
+    peaks.merge()
+    assert peaks == expected
+
+
+def test_PeakCollection_merge7_realworld_issue2():
+    peaks = PeakCollection(1_000_000)
+    peaks[:] = [Peak(1, 100, 200),
+                Peak(1, 150, 300), # <- You see this Peak's end position is longer than the next Peak?
+                Peak(1, 180, 200), # The above Peak should allow it to merge with the Peak below. 
+                Peak(1, 250, 400),
+                ]
+    expected = PeakCollection(1_000_000)
+    expected[:] = [
+            Peak(1, 100, 400),
+            ]
+    peaks.merge()
+    assert peaks == expected


### PR DESCRIPTION
Changelog:
1. Fixed bug where non-tophit variants would get excluded in the .csv and peakplot because LD information was not available for the variant
    - This occurs when there are no individuals with genotypes for both the tophit and other variant
2. Debugged `PeakCollection,merge` method which were missing some peaks to merge (Issue #16). 